### PR TITLE
Add CI check enforcing a perfect pub.dev (pana) score

### DIFF
--- a/.github/workflows/pana.yaml
+++ b/.github/workflows/pana.yaml
@@ -1,0 +1,23 @@
+name: Pana score
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  pana:
+    name: Check pub.dev score
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - uses: actions/checkout@v3
+      - run: dart --version
+      - run: dart pub get
+      - run: dart pub global activate pana
+      # Fail the build if any pub.dev points are lost (exit-code-threshold 0
+      # means the granted score must equal the maximum score).
+      - run: dart pub global run pana --no-warning --exit-code-threshold 0

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -24,4 +24,3 @@ linter:
     unawaited_futures: true
     unnecessary_parenthesis: true
     unnecessary_statements: true
-    unsafe_html: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - timezone
 
 environment:
-  sdk: '^3.5.0'
+  sdk: '^3.12.0'
 
 dependencies:
   collection: ^1.17.2

--- a/tool/utils/generate_class.dart
+++ b/tool/utils/generate_class.dart
@@ -133,6 +133,7 @@ String? generateClass<T>(
 
   if (!skipAddUnknown) {
     reference = {
+      // ignore: use_null_aware_elements
       if (unknown != null) reference[unknown]!: unknown,
       ...Map.fromEntries(
         reference.entries


### PR DESCRIPTION
## What

Adds a CI workflow that guarantees the package always scores the maximum on pub.dev, using `pana`.

`.github/workflows/pana.yaml` runs on PRs and pushes to `master`, activates `pana`, and runs it with `--exit-code-threshold 0` — the build fails if **any** pub.dev points are lost (granted score must equal the maximum).

## Why the score wasn't already perfect (150/160)

The 10-point gap was a formatting mismatch. The code generators format their output with `DartFormatter.latestLanguageVersion` (tall style), while `pana` / `dart format` format against the package's **declared** language version. At `sdk: '^3.5.0'` that was the old short style, so the committed generated files looked unformatted to pana.

Fix: bump the SDK floor to `^3.12.0` so both agree on tall style → **160/160**.

> Note: this raises the minimum SDK for consumers. Worth a CHANGELOG entry + version bump on the next release.

## Side-effects of the bump (fixed to keep `analyze-and-test` green)

`dart analyze --fatal-infos` picked up newer rules:
- Removed the `unsafe_html` lint from `analysis_options.yaml` (removed in Dart 3.7, now emits a `removed_lint` warning).
- Added a targeted `// ignore: use_null_aware_elements` in `tool/utils/generate_class.dart` — a null-aware rewrite there isn't behavior-preserving (the guard is on `unknown` while the map key is `reference[unknown]!`).

## Verification (local, Dart 3.12.2)

- `pana --exit-code-threshold 0` → **160/160**, exit 0
- `dart analyze --fatal-infos` → No issues found
- `dart test` → 6921 tests passed
- `dart tool/prepare_submit.dart` → no tracked-file diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)